### PR TITLE
[master][494200](UserStory) add markers to panels

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -107,6 +107,10 @@ class Pdf(object):
             self.canvas.drawRightString(panel_x + panel_width,
                                         panel_y - 7, '%04d' % (index + 1))
 
+            # Set the marker
+            if image_data['marker'] is not None:
+                self.canvas.drawString(panel_x, panel_y + panel_height + 2, image_data['marker'])
+
             # Set the dialogue
             self.__set_panel_dialogue(image_data)
 


### PR DESCRIPTION
This pull request adds markers to the top left corner of panels if present. Tested against sequences with no markers, sequences with markers for all panels, and sequences with markers for some panels but not the first few.

Input:
![Screenshot_20211105_175607](https://user-images.githubusercontent.com/885076/140556614-e8e31fc2-a014-4b54-b952-0816d94c0881.png)

Result:
![Screenshot_20211105_175636](https://user-images.githubusercontent.com/885076/140556696-366a857d-7fe5-442c-8694-461c3580c4b4.png)
