### PR TITLE
Update Blender Flix Version to 6.4.0

### DIFF
--- a/blender/blender-live-import.py
+++ b/blender/blender-live-import.py
@@ -50,7 +50,7 @@ def handshake(ws: websockets.WebSocketClientProtocol) -> Coroutine:
         'data': {
             'app': 'photoshop',
             'id': 'a8dcd02f',
-            'version': '6.3.5'
+            'version': '6.4.0'
         }
     }
     return ws.send(json.dumps(handshake_message))


### PR DESCRIPTION
Flix version in Blender script hardcoded to 6.3.5 which does not work on non-dev Flix Client builds, this PR updates to 6.4.0 which has been tested and works on non-dev Flix Client builds.