### PR TITLE
Panel revisioning example

### DIFF
--- a/flixpy/examples/revision_a_panel.py
+++ b/flixpy/examples/revision_a_panel.py
@@ -1,3 +1,9 @@
+"""
+This example shows how to create a new revision of a panel, using a new file for the new panel revision.
+
+The new panel revision will then be available within Flix. We are not creating a new sequence revision with this
+example.
+"""
 import asyncio
 
 import flix
@@ -43,11 +49,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    """
-    This example shows how to create a new revision of a panel, using a new file for the new panel revision.
-    
-    The new panel revision will then be available within Flix. We are not creating a new sequence revision with this
-    example.
-    """
-
     asyncio.run(main())

--- a/flixpy/examples/revision_a_panel.py
+++ b/flixpy/examples/revision_a_panel.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import flix
+
+# Authentication data
+HOSTNAME = "localhost"
+PORT = 8080
+USERNAME = "admin"
+PASSWORD = "admin"
+
+# Flix IDs
+SHOW_ID = 1
+SEQUENCE_ID = 1
+SEQUENCE_REVISION = 1
+PANEL_ID = 1
+PANEL_REVISION = 1
+
+# New file to be used to create the new panel revision
+FILEPATH = "./new_file.psd"
+
+
+async def main() -> None:
+    async with flix.Client(HOSTNAME, PORT) as client:
+        # Log into the Flix server
+        await client.authenticate(USERNAME, PASSWORD)
+        # Get the show from the server
+        show = await client.get_show(SHOW_ID)
+        # Create an 'artwork' media object with the file and transcode it to create a thumbnail
+        with open(FILEPATH, 'rb') as f:
+            asset = await show.upload_file(f, "artwork")
+        job_ids = await show.transcode_assets([asset])
+
+        # The transcodes do not need to complete before creating the panel revision
+        print(f"Thumbnail transcoding occurring in jobs: {job_ids}")
+
+        # Get the panel revision we want to update
+        sequence = await show.get_sequence(SEQUENCE_ID)
+        panel_revision = await sequence.get_panel_revision(PANEL_ID, PANEL_REVISION)
+        # Set the asset to be the one we've just created with the new file
+        panel_revision.asset = asset
+        # Create a new revision of the panel
+        await panel_revision.save()
+
+
+if __name__ == "__main__":
+    """
+    This example shows how to create a new revision of a panel, using a new file for the new panel revision.
+    
+    The new panel revision will then be available within Flix. We are not creating a new sequence revision with this
+    example.
+    """
+
+    asyncio.run(main())

--- a/flixpy/examples/revision_a_panel.py
+++ b/flixpy/examples/revision_a_panel.py
@@ -26,7 +26,7 @@ async def main() -> None:
         # Get the show from the server
         show = await client.get_show(SHOW_ID)
         # Create an 'artwork' media object with the file and transcode it to create a thumbnail
-        with open(FILEPATH, 'rb') as f:
+        with open(FILEPATH, "rb") as f:
             asset = await show.upload_file(f, "artwork")
         job_ids = await show.transcode_assets([asset])
 

--- a/flixpy/flix/lib/types.py
+++ b/flixpy/flix/lib/types.py
@@ -838,6 +838,18 @@ class Show(FlixType):
 
         return media_objects
 
+    async def transcode_assets(self, assets: list[Asset]) -> list[str]:
+        """
+        Transcodes an asset with an 'artwork' media object into thumbnail, scaled and fullres images
+        :param assets: The list of assets which need to be transcoded
+        :return: The list of task IDs which have been created to perform the transcode jobs.
+        """
+        path = f"/show/{self.show_id}/asset/transcode"
+        body = {"asset_ids": [a.asset_id for a in assets]}
+        tasks_model = TypedDict("tasks_model", {"task_ids": list[str]})
+        task_ids = cast(tasks_model, await self.client.post(path, body))
+        return task_ids["task_ids"]
+
     async def upload_file(self, f: BinaryIO, ref: str) -> Asset:
         asset = (await self.create_assets(1))[0]
         mo = await asset.create_media_object(ref)

--- a/flixpy/flix/lib/types.py
+++ b/flixpy/flix/lib/types.py
@@ -844,7 +844,7 @@ class Show(FlixType):
         :param assets: The list of assets which need to be transcoded
         :return: The list of task IDs which have been created to perform the transcode jobs.
         """
-        path = f"/show/{self.show_id}/asset/transcode"
+        path = f"{self.path_prefix()}/asset/transcode"
         body = {"asset_ids": [a.asset_id for a in assets]}
         tasks_model = TypedDict("tasks_model", {"task_ids": list[str]})
         task_ids = cast(tasks_model, await self.client.post(path, body))


### PR DESCRIPTION
Adding an example on how to revision a panel, using a new file.

Adding the `transcode_assets` method to the `flix.Client` to facilitate the above example