### PR TITLE
[develop][525854](UserStory) export missing types

### DIFF
--- a/flixpy/flix/lib/types.py
+++ b/flixpy/flix/lib/types.py
@@ -21,6 +21,11 @@ __all__ = [
     "Episode",
     "Sequence",
     "Asset",
+    "ContactSheetOrientation",
+    "ContactSheetStyle",
+    "ContactSheetPanelOptions",
+    "ContactSheetCoverOptions",
+    "ContactSheet",
     "Show",
     "Keyframe",
     "PanelComment",
@@ -28,7 +33,9 @@ __all__ = [
     "OriginAvid",
     "DuplicateRef",
     "PanelRevision",
+    "SequencePanel",
     "SequenceRevision",
+    "Server",
 ]
 
 


### PR DESCRIPTION
Add types that were missing from `__all__`, making them unavailable when importing the SDK as `import flix`