### PR TITLE
[main][562321](Bug) remove show id from media object model

### DIFF
--- a/flixpy/flix/lib/models.py
+++ b/flixpy/flix/lib/models.py
@@ -61,7 +61,6 @@ class MediaObject(TypedDict, total=False):
     status: int
     owner: User
     asset_type: str
-    show_id: int
 
 
 class Asset(TypedDict, total=False):

--- a/flixpy/flix/lib/types.py
+++ b/flixpy/flix/lib/types.py
@@ -473,7 +473,6 @@ class MediaObject(FlixType):
         status: MediaObjectStatus = MediaObjectStatus.INITIALIZED,
         owner: User | None = None,
         asset_type: str = "",
-        show_id: int = 0,
         *,
         _client: "client.Client | None",
     ):
@@ -488,7 +487,6 @@ class MediaObject(FlixType):
         self.status = status
         self.owner = owner
         self.asset_type = asset_type
-        self.show_id = show_id
 
     @classmethod
     def from_dict(
@@ -506,7 +504,6 @@ class MediaObject(FlixType):
         into.status = MediaObjectStatus(data["status"]) if data.get("status") else MediaObjectStatus.INITIALIZED
         into.owner = User.from_dict(data["owner"], _client=_client) if data.get("owner") else None
         into.asset_type = data.get("asset_type", "")
-        into.show_id = data.get("show_id", 0)
         into._client = _client
         return into
 


### PR DESCRIPTION
Removes the show ID from media objects as they're not provided by the API anymore. Verified that type checking still passes.