### PR TITLE
[main][562352](UserStory) How to automate updates to SG based on an event from Flix

### DIFF
--- a/flixpy/examples/shotgrid_create_show.py
+++ b/flixpy/examples/shotgrid_create_show.py
@@ -178,11 +178,13 @@ async def upload_thumbnail(show: flix.Show, image_url: str) -> flix.Asset:
     Returns:
         The newly created asset for the show thumbnail.
     """
+    # request the image from ShotGrid
     async with aiohttp.ClientSession() as session, session.get(image_url) as response:
         if response.content_length is None:
             # we can't stream an upload to Flix if we don't know the size in advance
             raise ValueError("Content length not set")
 
+        # stream the image to Flix
         return await show.upload_stream(
             # stream image in 8 MiB chunks
             response.content.iter_chunked(1024*1024*8),

--- a/flixpy/examples/shotgrid_create_show.py
+++ b/flixpy/examples/shotgrid_create_show.py
@@ -1,4 +1,4 @@
-"""Demonstrate creating a show in Flix from an existing ShotGrid project.
+"""Demonstrates creating a show in Flix from an existing ShotGrid project.
 
 This example fetches project and sequence data from ShotGrid
 and creates a Flix show containing sequences with matching descriptions.

--- a/flixpy/examples/shotgrid_create_show.py
+++ b/flixpy/examples/shotgrid_create_show.py
@@ -19,7 +19,7 @@ from typing import TypedDict, cast
 
 import aiohttp
 import flix
-import shotgun_api3  # type: ignore[import]
+import shotgun_api3  # type: ignore[import-untyped]
 
 # ShotGrid credentials and project ID to fetch the project data from
 SHOTGRID_BASE_URL = "https://yourstudio.shotgunstudio.com/"

--- a/flixpy/examples/shotgrid_create_show.py
+++ b/flixpy/examples/shotgrid_create_show.py
@@ -13,7 +13,6 @@ Note that this example does not take shots into account.
 
 import asyncio
 import logging
-import os
 import re
 from typing import TypedDict, cast
 
@@ -133,7 +132,7 @@ def get_show_tracking_code(sg_project: ShotgridProject) -> str:
         # can't guess a tracking code if we have no name
         return ""
 
-    # try to use
+    # try to use the first letter of each capitalised word in the title
     initials = "".join(word[0] for word in name.split() if len(word) > 0 and word[0].isupper())
     if len(sanitized_initials := sanitize_tracking_code(initials)) >= 3:
         return sanitized_initials
@@ -172,9 +171,6 @@ async def upload_thumbnail(show: flix.Show, image_url: str) -> flix.Asset:
     This function uploads the file without saving the file to disk,
     passing the data directly to Flix as it's downloaded.
 
-    Demonstrates how you can build more complex data flows
-    with asynchronous functions without using threads.
-
     Args:
         show: The show to upload the thumbnail to.
         image_url: The URL to download the thumbnail from.
@@ -182,49 +178,18 @@ async def upload_thumbnail(show: flix.Show, image_url: str) -> flix.Asset:
     Returns:
         The newly created asset for the show thumbnail.
     """
-    async with aiohttp.ClientSession() as session, session.get(image_url) as resp:
-        # create a file pipe to connect the downloader to the uploader
-        r, w = os.pipe()
-        # run download and upload in parallel
-        # so the downloader can feed the data to the uploader
-        downloader = asyncio.create_task(_download_file(resp, w))
-        uploader = asyncio.create_task(_upload_file(show, resp, r))
+    async with aiohttp.ClientSession() as session, session.get(image_url) as response:
+        if response.content_length is None:
+            # we can't stream an upload to Flix if we don't know the size in advance
+            raise ValueError("Content length not set")
 
-        try:
-            # wait for download and upload to complete
-            _, pending = await asyncio.wait(
-                [downloader, uploader], return_when=asyncio.FIRST_EXCEPTION
-            )
-        finally:
-            # if either task failed, make sure we cancel the other
-            for task in pending:
-                task.cancel()
-
-        # get the asset returned by upload_file()
-        return uploader.result()
-
-
-async def _upload_file(show: flix.Show, response: aiohttp.ClientResponse, r: int) -> flix.Asset:
-    """Read data from a pipe and upload to Flix as a show thumbnail."""
-    # pass the read end of the pipe to upload_file()
-    # to upload the data written by the downloader
-    with os.fdopen(r, "rb") as reader:
-        return await show.upload_file(
-            reader,
+        return await show.upload_stream(
+            # stream image in 8 MiB chunks
+            response.content.iter_chunked(1024*1024*8),
             flix.AssetType.SHOW_THUMBNAIL,
             name=response.url.name,
             size=response.content_length,
         )
-
-
-async def _download_file(response: aiohttp.ClientResponse, w: int) -> None:
-    """Download data from ShotGrid and write to a pipe."""
-    # read the response from ShotGrid and pass the data to the uploader using the pipe
-    # note: important to close the writer to signal the end of the file
-    # (this is automatically handled by the 'with' statement)
-    with os.fdopen(w, "wb") as writer:
-        async for chunk in response.content.iter_chunked(1024 * 1024 * 10):
-            writer.write(chunk)
 
 
 if __name__ == "__main__":

--- a/flixpy/examples/shotgrid_version_sequence.py
+++ b/flixpy/examples/shotgrid_version_sequence.py
@@ -1,0 +1,181 @@
+"""Demonstrates automatically creating a new ShotGrid version on a publish to editorial.
+
+This example shows how to use webhooks to listen for publishes from Flix to editorial
+and automatically create a new version in ShotGrid. The new version will be linked to a sequence
+and have a QuickTime exported from the Flix sequence revision attached.
+
+The code assumes that you have attached the IDs of your ShotGrid project and sequence
+to the metadata of your Flix show and sequence respectively, in the form of a ``shotgrid_id`` field.
+See ``shotgrid_create_show.py`` for an example on how to do that.
+
+Additionally, you must have registered a webhook with the Flix Server, either using
+the ``/webhook`` endpoint or the ``flix webhook`` command from the Flix SDK.
+The example assumes that you have registered a TCP webhook with the URL
+``http://<hostname>:8888/events/shotgrid`` with the ``Publish to editorial``
+event enabled.
+"""
+
+import asyncio
+import contextlib
+import logging
+import pathlib
+import tempfile
+from typing import Literal, TypedDict, cast
+
+import shotgun_api3  # type: ignore[import-untyped]
+from typing_extensions import NotRequired
+
+import flix
+
+logger = logging.getLogger(__name__)
+
+# ShotGrid credentials to create the new version
+SHOTGRID_BASE_URL = "https://yourstudio.shotgunstudio.com/"
+SHOTGRID_USERNAME = "user.name@example.com"
+SHOTGRID_PASSWORD = "hunter2"
+
+# Flix server and credentials for exporting the QuickTime
+FLIX_HOSTNAME = "localhost"
+FLIX_PORT = 8080
+FLIX_USERNAME = "admin"
+FLIX_PASSWORD = "admin"
+
+# create long-lived ShotGrid client so we don't need
+# to create a new one for each event
+SG = shotgun_api3.Shotgun(
+    SHOTGRID_BASE_URL, login=SHOTGRID_USERNAME, password=SHOTGRID_PASSWORD
+)
+
+
+# optional: typed schemas for our ShotGrid entities for use with Mypy/Pyright
+class BaseSchema(TypedDict):
+    """Common base schema for entities with IDs."""
+    id: int
+
+
+class ShotgridProject(BaseSchema):
+    """Typed schema for existing ShotGrid projects."""
+    type: Literal["Project"]
+
+
+class ShotgridSequence(BaseSchema):
+    """Typed schema for existing ShotGrid sequences."""
+    type: Literal["Sequence"]
+
+
+class ShotgridVersion(TypedDict):
+    """Typed schema for new ShotGrid versions."""
+    project: ShotgridProject
+    entity: NotRequired[ShotgridSequence]
+    code: str
+    description: NotRequired[str | None]
+
+
+class ShotgridVersionWithID(BaseSchema, ShotgridVersion):
+    """Typed schema for existing ShotGrid versions."""
+    type: Literal["Project"]
+
+
+# specify the HTTP endpoint for your webhook, as well as
+# the secret you got when registering the webhook with the server
+@flix.webhook(path="/events/shotgrid", secret="3a990b93-d661-4540-80ce-f4a421c528df")
+async def on_event(event: flix.WebhookEvent) -> None:
+    """Handle all events enabled for this webhook."""
+    logger.info("Got event: %s", event)
+
+
+@on_event.handle(flix.PublishEditorialEvent)
+async def on_publish(event: flix.PublishEditorialEvent) -> None:
+    """Handle editorial publish events."""
+    logger.info(
+        "Got publish event for show %s, sequence %s, revision %s",
+        event.show.tracking_code,
+        event.sequence.tracking_code,
+        event.sequence_revision.revision_number,
+    )
+
+    # export QuickTime - requires that we have passed client_options
+    # to flix.run_webhook_server to ensure that we have an authenticated client
+    logger.info("Exporting QuickTime...")
+    quicktime_mo = await event.sequence_revision.export_quicktime()
+
+    # create a temporary directory for downloading the QuickTime
+    with tempfile.TemporaryDirectory() as dir_path:
+        logger.info("Downloading QuickTime...")
+        quicktime_path = await quicktime_mo.download_to(dir_path)
+
+        # create the new ShotGrid version and upload the QuickTime
+        # optional: run on a different thread to prevent the synchronous
+        # ShotGrid calls from blocking processing of other events
+        await asyncio.get_running_loop().run_in_executor(
+            None, _upload_to_shotgrid, event, quicktime_path
+        )
+
+
+def _upload_to_shotgrid(
+    event: flix.PublishEditorialEvent, quicktime_path: pathlib.Path
+) -> None:
+    """Create a new ShotGrid version from a Flix sequence revision and attach a QuickTime."""
+    logger.info("Creating new ShotGrid version...")
+    version = cast(ShotgridVersionWithID, SG.create("Version", _version_from_publish(event)))
+
+    logger.info("Uploading QuickTime to ShotGrid...")
+    SG.upload(
+        entity_type=version["type"],
+        entity_id=version["id"],
+        path=str(quicktime_path),
+        field_name="sg_uploaded_movie",
+        # display_name="Some display name",
+    )
+
+
+def _version_from_publish(event: flix.PublishEditorialEvent) -> ShotgridVersion:
+    """Construct a ShotGrid version entity from a publish event."""
+    project_id = event.show.metadata.get_int("shotgrid_id")
+    sequence_id = event.sequence.metadata.get_int("shotgrid_id")
+    if project_id is None or sequence_id is None:
+        raise ValueError("The ShotGrid ID must be set on the Flix show and sequence")
+
+    code = "{show_tracking_code}_{sequence_tracking_code}_v{revision_number:03}".format(
+        show_tracking_code=event.show.tracking_code,
+        sequence_tracking_code=event.sequence.tracking_code,
+        revision_number=event.sequence_revision.revision_number or 0,
+    )
+    return ShotgridVersion(
+        code=code,
+        description=event.sequence_revision.comment or None,
+        project=ShotgridProject(
+            id=project_id,
+            type="Project",
+        ),
+        entity=ShotgridSequence(
+            id=sequence_id,
+            type="Sequence",
+        ),
+    )
+
+
+async def run_publish_webhook() -> None:
+    """Run the webhook server until interrupted."""
+    # ensure we close the ShotGrid client when exiting
+    with contextlib.closing(SG):
+        await flix.run_webhook_server(
+            on_event,
+            port=8888,
+            # pass client options to the webhook runner
+            # so we can run methods that communicate with
+            # the Flix Server
+            client_options={
+                "hostname": FLIX_HOSTNAME,
+                "port": FLIX_PORT,
+                "username": FLIX_USERNAME,
+                "password": FLIX_PASSWORD,
+            },
+        )
+
+
+if __name__ == "__main__":
+    # enable logging
+    logging.basicConfig(level=logging.INFO)
+    # start the server
+    asyncio.run(run_publish_webhook())

--- a/flixpy/examples/update_sequence_metadata.py
+++ b/flixpy/examples/update_sequence_metadata.py
@@ -4,7 +4,7 @@ import asyncio
 
 import flix
 
-HOSTNAME = "arvid-foundry"
+HOSTNAME = "localhost"
 PORT = 8080
 USERNAME = "admin"
 PASSWORD = "admin"

--- a/flixpy/examples/webhook_server.py
+++ b/flixpy/examples/webhook_server.py
@@ -1,9 +1,9 @@
-import aiohttp.web
+import asyncio
 
 import flix
 
 
-@flix.webhook(secret="572399cf-065a-4413-a2ec-6b288d3b6928")
+@flix.webhook(path="/events", secret="572399cf-065a-4413-a2ec-6b288d3b6928")
 async def on_event(event: flix.WebhookEvent) -> None:
     print("Got event:", event)
 
@@ -21,6 +21,4 @@ async def on_publish_flix(event: flix.PublishFlixEvent) -> None:
 if __name__ == "__main__":
     # you can also set the secret separately:
     # on_event.set_secret("572399cf-065a-4413-a2ec-6b288d3b6928")
-    app = aiohttp.web.Application()
-    app.add_routes([aiohttp.web.post("/events", on_event)])
-    aiohttp.web.run_app(app, port=8888)
+    asyncio.run(flix.run_webhook_server(on_event, port=8888))

--- a/flixpy/flix/extension/client.py
+++ b/flixpy/flix/extension/client.py
@@ -107,7 +107,7 @@ class EventQueue(AsyncIterable[_ET]):
                 break
 
             if isinstance(event, self._event_types):
-                yield cast(_ET, event)
+                yield event
 
             if self._queue is not None:
                 self._queue.task_done()

--- a/flixpy/flix/lib/client.py
+++ b/flixpy/flix/lib/client.py
@@ -285,9 +285,14 @@ class BaseClient:
         self._access_key = AccessKey(await response.json())
         return self._access_key
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         """Closes the underlying HTTP session. Does not need to be called when using the client as a context manager."""
         await self._session.close()
+
+    async def close(self) -> None:
+        """Deprecated. Use ``aclose()``."""
+        warnings.warn("Use Client.aclose()", DeprecationWarning)
+        await self.aclose()
 
     async def __aenter__(self: ClientSelf) -> ClientSelf:
         return self
@@ -295,7 +300,7 @@ class BaseClient:
     async def __aexit__(
         self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
-        await self.close()
+        await self.aclose()
 
 
 class Client(BaseClient):

--- a/flixpy/flix/lib/client.py
+++ b/flixpy/flix/lib/client.py
@@ -1,18 +1,24 @@
+import asyncio
 import base64
-import urllib.parse
-
-from collections.abc import Mapping
+import contextlib
 import dataclasses
+import datetime
 import json
+import logging
+import urllib.parse
+import warnings
+from collections.abc import AsyncIterator, Mapping
 from types import TracebackType
-from typing import Any, cast, Type, TypedDict, TypeVar
+from typing import Any, Type, TypedDict, TypeVar, cast
 
 import aiohttp
 import dateutil.parser
 
-from . import signing, errors, forms, types, models, utils, websocket
+from . import errors, forms, models, signing, types, utils, websocket
 
 __all__ = ["Client", "AccessKey"]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -28,6 +34,12 @@ class AccessKey:
         self.secret_access_key: str = access_key["secret_access_key"]
         self.created_date = dateutil.parser.parse(access_key["created_date"])
         self.expiry_date = dateutil.parser.parse(access_key["expiry_date"])
+
+    @property
+    def has_expired(self) -> bool:
+        """Whether this access key has expired."""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return self.expiry_date < now
 
     def to_json(self) -> dict[str, Any]:
         """Returns a JSON-serialisable representation of this access key.
@@ -54,6 +66,9 @@ class BaseClient:
         ssl: bool = False,
         disable_ssl_validation: bool = False,
         *,
+        username: str | None = None,
+        password: str | None = None,
+        auto_extend_session: bool = True,
         access_key: AccessKey | None = None,
     ):
         """
@@ -62,14 +77,24 @@ class BaseClient:
         :param port: The port the server is running on
         :param ssl: Whether to use HTTPS to communicate with the server
         :param disable_ssl_validation: Whether to disable validation of SSL certificates; enables MITM attacks
+        :param username: The user to authenticate as. If provided, the client will automatically
+            authenticate whenever we don't have a valid session.
+        :param password: The password for the user to authenticate as. Must be provided if ``username`` is provided.
+        :param auto_extend_session: Automatically keep the session alive by periodically extending
+            the access key validity time following a successful authentication.
         :param access_key: The access key of an already authenticated user.
         """
         self._hostname = hostname
         self._port = port
         self._ssl = ssl
-        self._access_key = access_key
-        self._session = aiohttp.ClientSession()
         self._disable_ssl_validation = disable_ssl_validation
+        self._username = username
+        self._password = password
+        self._auto_extend_session = auto_extend_session
+        self._access_key = access_key
+
+        self._session = aiohttp.ClientSession()
+        self._refresh_token_task: asyncio.Task[None] | None = None
 
     @property
     def access_key(self) -> AccessKey | None:
@@ -160,7 +185,15 @@ class BaseClient:
         :raises errors.FlixError: If the server returned an error
         :return: The HTTP response
         """
-        return await self._request(method, path, body, **kwargs)
+        # authenticate if auto auth is enabled and we don't have a valid access key
+        await self._ensure_authenticated()
+        try:
+            return await self._request(method, path, body, **kwargs)
+        except errors.FlixNotVerifiedError:
+            # if our access key was rejected it will be cleared by _request, so try again
+            if not await self._ensure_authenticated():
+                raise
+            return await self._request(method, path, body, **kwargs)
 
     async def request_json(self, method: str, path: str, body: Any | None = None, **kwargs: Any) -> dict[str, Any]:
         """
@@ -280,13 +313,69 @@ class BaseClient:
         :raises errors.FlixError: If the server returned an error
         """
         self._access_key = None
-        # call _request directly to avoid recursion during interactive sessions
+        # call _request directly to avoid recursion when automatically authenticating
         response = await self._request("POST", "/authenticate", auth=aiohttp.BasicAuth(user, password))
         self._access_key = AccessKey(await response.json())
+
+        if self._refresh_token_task is None and self._auto_extend_session:
+            self._refresh_token_task = asyncio.create_task(self._periodically_refresh_token())
+
         return self._access_key
+
+    async def _ensure_authenticated(self) -> bool:
+        """Authenticate with the Flix Server if we have no valid access key.
+
+        Returns:
+            ``True`` if a successful authentication attempt was performed;
+                ``False`` if no attempt was made because the access key is still valid
+                or automatic authentication is disabled.
+        """
+        if (
+            (
+                self._access_key is None
+                or self._access_key.has_expired
+            )
+            and self._username is not None
+            and self._password is not None
+        ):
+            await self.authenticate(self._username, self._password)
+            return True
+        return False
+
+    async def extend_session(self) -> None:
+        """Extend the current login session to 24 hours from now.
+
+        If the current access key is not valid, this method does nothing.
+        """
+        if self._access_key is None:
+            return
+
+        try:
+            self._access_key = AccessKey(await self.post("/authenticate/extend"))
+        except errors.FlixNotVerifiedError:
+            # the access key has expired; we'll reauthenticate before the next request
+            pass
+
+    async def _periodically_refresh_token(self) -> None:
+        """Try to extend the session once an hour."""
+        refresh_frequency_seconds = 60 * 60
+        while True:
+            await asyncio.sleep(refresh_frequency_seconds)
+
+            if self._access_key is not None:
+                try:
+                    await self.extend_session()
+                except Exception:
+                    logger.exception(
+                        "error while trying to extend the current session, will try again in %s seconds",
+                        refresh_frequency_seconds,
+                    )
 
     async def aclose(self) -> None:
         """Closes the underlying HTTP session. Does not need to be called when using the client as a context manager."""
+        if self._refresh_token_task is not None:
+            self._refresh_token_task.cancel()
+
         await self._session.close()
 
     async def close(self) -> None:
@@ -306,27 +395,11 @@ class BaseClient:
 class Client(BaseClient):
     """An extension of BaseClient, providing helper functions for interacting with the Flix API."""
 
-    def __init__(
-        self,
-        hostname: str,
-        port: int,
-        ssl: bool = False,
-        disable_ssl_validation: bool = False,
-        *,
-        access_key: AccessKey | None = None,
-    ):
-        """
-        Instantiate a new Flix client.
-        :param hostname: The hostname of the Flix server
-        :param port: The port the server is running on
-        :param ssl: Whether to use HTTPS to communicate with the server
-        :param disable_ssl_validation: Whether to disable validation of SSL certificates; enables MITM attacks
-        :param access_key: The access key of an already authenticated user.
-        """
-        super().__init__(hostname, port, ssl, disable_ssl_validation=disable_ssl_validation, access_key=access_key)
-
-    def websocket(self) -> websocket.Websocket:
-        return websocket.Websocket(self._session, self)
+    @contextlib.asynccontextmanager
+    async def websocket(self) -> AsyncIterator[websocket.Websocket]:
+        await self._ensure_authenticated()
+        async with websocket.Websocket(self._session, self) as ws:
+            yield ws
 
     async def get_all_shows(self, include_hidden: bool = False) -> list[types.Show]:
         params = {"display_hidden": "true" if include_hidden else "falsae"}

--- a/flixpy/flix/lib/errors.py
+++ b/flixpy/flix/lib/errors.py
@@ -4,13 +4,13 @@ import dataclasses
 __all__ = ["FlixError", "FlixHTTPError", "FlixNotVerifiedError"]
 
 
-class FlixError(OSError):
-    pass
+class FlixError(Exception):
+    """A generic Flix error."""
 
 
 @dataclasses.dataclass
 class FlixHTTPError(FlixError):
-    """A generic Flix error."""
+    """An error resulting from a failed HTTP request."""
 
     status_code: int
     error_message: str

--- a/flixpy/flix/lib/transfers.py
+++ b/flixpy/flix/lib/transfers.py
@@ -1,32 +1,24 @@
 import json
-import os
 import pathlib
 import random
 import ssl
 import uuid
-from collections.abc import Iterable
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
 from typing import (
+    TYPE_CHECKING,
     BinaryIO,
-    Callable,
     Union,
-    AsyncIterable,
-    AsyncIterator,
     Type,
     TypeVar,
     cast,
-    TYPE_CHECKING,
 )
 
 import grpc.aio
 from cryptography import x509
 from grpc.aio import ClientCallDetails, StreamStreamCall
 
-from . import client, errors, types, signing
+from . import client, errors, signing, types
 from .proto import transfer_pb2_grpc, transfer_pb2
-
-
-_CHUNK_SIZE = 8 * 1024
-
 
 Streamer = Callable[[bytes], AsyncIterator[transfer_pb2.TransferReq]]
 RequestType = TypeVar("RequestType")
@@ -54,7 +46,12 @@ def download_streamer() -> Streamer:
     return streamer
 
 
-def upload_streamer(f: BinaryIO, *, name: str, size: int) -> Streamer:
+async def chunk_file(f: BinaryIO, chunk_size: int = 8 * 1024) -> AsyncIterator[bytes]:
+    while data := f.read(chunk_size):
+        yield data
+
+
+def upload_streamer(f: AsyncIterable[bytes], *, name: str, size: int) -> Streamer:
     async def streamer(metadata: bytes) -> AsyncIterator[transfer_pb2.TransferReq]:
         suffix = pathlib.Path(name).suffix
         transfer_id = str(uuid.uuid4())
@@ -70,7 +67,7 @@ def upload_streamer(f: BinaryIO, *, name: str, size: int) -> Streamer:
             UUID=transfer_id,
         )
 
-        while data := f.read(_CHUNK_SIZE):
+        async for data in f:
             yield transfer_pb2.TransferReq(
                 DataMsg=transfer_pb2.TransferReq.DataMessage(
                     Action=transfer_pb2.TransferReq.DataMessage.DATA,
@@ -188,20 +185,13 @@ async def transfer(
 
 async def upload(
     flix_client: "client.Client",
-    f: BinaryIO,
+    f: AsyncIterable[bytes],
     asset_id: int,
     media_object_id: int,
     *,
-    name: str | None = None,
-    size: int | None = None,
+    name: str,
+    size: int,
 ) -> None:
-    if name is None:
-        name = f.name
-    if size is None:
-        f.seek(0, os.SEEK_END)
-        size = f.tell()
-        f.seek(0, os.SEEK_SET)
-
     stream = transfer(
         flix_client,
         asset_id,

--- a/flixpy/flix/lib/transfers.py
+++ b/flixpy/flix/lib/transfers.py
@@ -21,7 +21,7 @@ import grpc.aio
 from cryptography import x509
 from grpc.aio import ClientCallDetails, StreamStreamCall
 
-from . import client, types, signing
+from . import client, errors, types, signing
 from .proto import transfer_pb2_grpc, transfer_pb2
 
 
@@ -160,7 +160,7 @@ async def transfer(
 ) -> AsyncIterator[transfer_pb2.TransferResp]:
     access_key = flix_client.access_key
     if access_key is None:
-        raise RuntimeError("must authenticate before transferring files")
+        raise errors.FlixError("must authenticate before transferring files")
 
     servers = await flix_client.servers()
     server: "types.Server" = random.choice(servers)

--- a/flixpy/flix/lib/types.py
+++ b/flixpy/flix/lib/types.py
@@ -58,7 +58,7 @@ class FlixType:
     @property
     def client(self) -> "client.Client":
         if self._client is None:
-            raise RuntimeError("client is not set")
+            raise errors.FlixError("client is not set")
         return self._client
 
 
@@ -251,7 +251,7 @@ class Metadata(FlixType, MutableMapping[str, Any]):
 
     def path_prefix(self) -> str:
         if self._parent is None:
-            raise RuntimeError("metadata parent is not set")
+            raise errors.FlixError("metadata parent is not set")
         return f"{self._parent.path_prefix()}/metadata"
 
     class _MetadataModel(TypedDict):
@@ -1188,7 +1188,7 @@ class Show(FlixType):
         description: str = "",
     ) -> Episode:
         if not self.episodic:
-            raise RuntimeError("cannot create an episode in a non-episodic show")
+            raise errors.FlixError("cannot create an episode in a non-episodic show")
         return Episode(
             episode_number=episode_number,
             tracking_code=tracking_code,
@@ -1481,7 +1481,7 @@ class Panel(FlixType):
 
     def path_prefix(self) -> str:
         if self._sequence is None:
-            raise RuntimeError("sequence is not set")
+            raise errors.FlixError("sequence is not set")
         return f"{self._sequence.path_prefix(False)}/panel/{self.panel_id}"
 
 
@@ -1608,7 +1608,7 @@ class PanelRevision(FlixType):
 
     def path_prefix(self, include_episode: bool = False) -> str:
         if self._sequence is None:
-            raise RuntimeError("sequence is not set")
+            raise errors.FlixError("sequence is not set")
         return f"{self._sequence.path_prefix(include_episode)}/panel/{self.panel_id}/revision/{self.revision_number}"
 
     def new_sequence_panel(
@@ -1652,7 +1652,7 @@ class PanelRevision(FlixType):
 
     async def save(self, force_create_new_panel: bool = False) -> None:
         if self._sequence is None:
-            raise RuntimeError("sequence is not set")
+            raise errors.FlixError("sequence is not set")
 
         if self.panel_id is None or force_create_new_panel:
             path = f"{self._sequence.path_prefix()}/panel"
@@ -1781,7 +1781,7 @@ class SequenceRevision(FlixType):
 
     def path_prefix(self, include_episode: bool = True) -> str:
         if self._sequence is None:
-            raise RuntimeError("sequence is not set")
+            raise errors.FlixError("sequence is not set")
         return f"{self._sequence.path_prefix(include_episode)}/revision/{self.revision_number}"
 
     def add_panel(
@@ -1858,7 +1858,7 @@ class SequenceRevision(FlixType):
 
     async def save(self, force_create_new: bool = False) -> None:
         if self._sequence is None:
-            raise RuntimeError("sequence is not set")
+            raise errors.FlixError("sequence is not set")
 
         if self.revision_number is None or force_create_new:
             path = f"{self._sequence.path_prefix()}/revision"

--- a/flixpy/flix/lib/types.py
+++ b/flixpy/flix/lib/types.py
@@ -536,9 +536,27 @@ class MediaObject(FlixType):
             pass
 
     async def download(self) -> bytes:
+        """Get the file contents of this media object.
+
+        This function should not be used to download large files
+        that may not fit in memory.
+
+        Returns:
+            A byte string containing the entire file contents of this media object.
+        """
         return b"".join([chunk async for chunk in transfers.download(self.client, self.asset_id, self.media_object_id)])
 
-    async def download_to(self, directory: str | os.PathLike[str], filename: str | None = None) -> None:
+    async def download_to(self, directory: str | os.PathLike[str], filename: str | None = None) -> pathlib.Path:
+        """Save this media object's file contents to disk.
+
+        Args:
+            directory: The directory to download the file to.
+            filename: The name of the file inside the directory.
+                If not specified, a unique filename for this media object will be picked.
+
+        Returns:
+            The path to the saved file.
+        """
         dirpath = pathlib.Path(directory)
         dirpath.mkdir(parents=True, exist_ok=True)
         if filename is None:
@@ -549,6 +567,8 @@ class MediaObject(FlixType):
         with path.open("wb") as f:
             async for chunk in transfers.download(self.client, self.asset_id, self.media_object_id):
                 f.write(chunk)
+
+        return path
 
 
 class Episode(FlixType):

--- a/flixpy/flix/lib/webhooks.py
+++ b/flixpy/flix/lib/webhooks.py
@@ -1,13 +1,14 @@
 import enum
 import json
 import logging
-from typing import Callable, Any, Coroutine, TypeVar, Type, cast
+from typing import Callable, Any, Coroutine, TypeVar, cast
 
 import aiohttp.web
 import dateutil.parser
+from typing_extensions import TypeAlias
 
 import flix
-from flix.lib import errors, models, types
+from flix.lib import client as _client, errors, models, types
 
 __all__ = [
     "EventType",
@@ -18,9 +19,12 @@ __all__ = [
     "ExportSBPEvent",
     "NewSequenceRevisionEvent",
     "NewPanelRevisionEvent",
+    "NewContactSheetEvent",
     "PingEvent",
     "WebhookHandler",
     "webhook",
+    "WebhookHandlerType",
+    "EventFactory",
 ]
 
 logger = logging.getLogger(__name__)
@@ -45,99 +49,190 @@ class WebhookEvent:
         self.event_payload = event_data
 
 
+EventModelType = TypeVar("EventModelType", bound=models.Event)
+WebhookEventType = TypeVar("WebhookEventType", bound=WebhookEvent)
+WebhookHandlerType = Callable[[WebhookEventType], Coroutine[Any, Any, None]]
+EventFactory: TypeAlias = Callable[
+    [models.Event, _client.Client | None], WebhookEventType
+]
+
+_EVENT_TYPES: dict[EventType, EventFactory[WebhookEvent]] = {}
+
+
+def _event(
+    event_type: EventType,
+) -> Callable[[EventFactory[WebhookEventType]], EventFactory[WebhookEventType]]:
+    """Registers a class as an event type."""
+
+    def _register_event(
+        f: EventFactory[WebhookEventType],
+    ) -> EventFactory[WebhookEventType]:
+        _EVENT_TYPES[event_type] = f
+        return f
+
+    return _register_event
+
+
+@_event(EventType.ERROR)
 class ErrorEvent(WebhookEvent):
     """An event sent when an error is logged by the Flix server."""
 
-    def __init__(self, event_data: models.ErrorEvent):
-        super().__init__(event_data)
+    def __init__(self, data: models.Event, _: _client.Client | None):
+        super().__init__(data)
+        event_data = cast(models.ErrorEvent, data)
         self.message = event_data["message"]
         self.fields = event_data["fields"]
 
 
+@_event(EventType.PUBLISH_EDITORIAL)
 class PublishEditorialEvent(WebhookEvent):
     """An event sent when publishing from Flix to editorial."""
 
-    def __init__(self, event_data: models.PublishToEditorialEvent):
-        super().__init__(event_data)
+    def __init__(
+        self,
+        data: models.Event,
+        client: _client.Client | None,
+    ):
+        super().__init__(data)
+        event_data = cast(models.PublishToEditorialEvent, data)
         self.target_app = event_data["target_app"]
-        self.user = types.User.from_dict(event_data["user"], _client=None)
+        self.user = types.User.from_dict(event_data["user"], _client=client)
         self.created_media_objects = [
-            types.MediaObject.from_dict(mo, _client=None) for mo in event_data["created_media_objects"]
+            types.MediaObject.from_dict(mo, _client=client)
+            for mo in event_data["created_media_objects"]
         ]
-        self.show = types.Show.from_dict(event_data["show"], _client=None)
-        self.sequence = types.Sequence.from_dict(event_data["sequence"], _show=self.show, _client=None, _episode=None)
+        self.show = types.Show.from_dict(event_data["show"], _client=client)
+        self.sequence = types.Sequence.from_dict(
+            event_data["sequence"], _show=self.show, _client=client, _episode=None
+        )
         self.sequence_revision = types.SequenceRevision.from_dict(
-            event_data["sequence_revision"], _client=None, _sequence=self.sequence
+            event_data["sequence_revision"],
+            _client=client,
+            _sequence=self.sequence,
         )
 
 
+@_event(EventType.PUBLISH_FLIX)
 class PublishFlixEvent(WebhookEvent):
     """An event sent when publishing from editorial to Flix."""
 
-    def __init__(self, event_data: models.PublishToFlixEvent):
-        super().__init__(event_data)
+    def __init__(self, data: models.Event, client: _client.Client | None):
+        super().__init__(data)
+        event_data = cast(models.PublishToFlixEvent, data)
         self.source_app = event_data["source_app"]
-        self.user = types.User.from_dict(event_data["user"], _client=None)
-        self.show = types.Show.from_dict(event_data["show"], _client=None)
-        self.sequence = types.Sequence.from_dict(event_data["sequence"], _show=self.show, _client=None, _episode=None)
+        self.user = types.User.from_dict(event_data["user"], _client=client)
+        self.show = types.Show.from_dict(event_data["show"], _client=client)
+        self.sequence = types.Sequence.from_dict(
+            event_data["sequence"], _show=self.show, _episode=None, _client=client
+        )
         self.new_sequence_revision = types.SequenceRevision.from_dict(
-            event_data["new_sequence_revision"], _client=None, _sequence=self.sequence
+            event_data["new_sequence_revision"],
+            _sequence=self.sequence,
+            _client=client,
         )
 
 
+_SparseIDs = models.SequenceRevision | models.PanelRevision
+
+
+def _sparse_show(data: _SparseIDs, client: _client.Client | None) -> types.Show:
+    """Create a sparse show from just IDs for events that don't include show data."""
+    return types.Show(show_id=data["show_id"], _client=client)
+
+
+def _sparse_sequence(data: _SparseIDs, client: _client.Client | None) -> types.Sequence:
+    """Create a sparse sequence from just IDs for events that don't include sequence data."""
+    return types.Sequence(
+        sequence_id=data["sequence_id"],
+        _show=_sparse_show(data, client),
+        _episode=None,
+        _client=client,
+    )
+
+
+@_event(EventType.EXPORT_SBP)
 class ExportSBPEvent(WebhookEvent):
     """An event sent when exporting a sequence revision to Storyboard Pro."""
 
-    def __init__(self, event_data: models.ExportToSBPEvent):
-        super().__init__(event_data)
+    def __init__(self, data: models.Event, client: _client.Client | None):
+        super().__init__(data)
+        event_data = cast(models.ExportToSBPEvent, data)
         self.sequence_revision = types.SequenceRevision.from_dict(
-            event_data["sequence_revision"], _client=None, _sequence=None
+            event_data["sequence_revision"],
+            _sequence=_sparse_sequence(event_data["sequence_revision"], client),
+            _client=client,
         )
 
 
+@_event(EventType.NEW_SEQUENCE_REVISION)
 class NewSequenceRevisionEvent(WebhookEvent):
     """An event sent when a new sequence revision is saved."""
 
-    def __init__(self, event_data: models.SequenceRevisionCreatedEvent):
-        super().__init__(event_data)
+    def __init__(
+        self,
+        data: models.Event,
+        client: _client.Client | None,
+    ):
+        super().__init__(data)
+        event_data = cast(models.SequenceRevisionCreatedEvent, data)
         self.sequence_revision = types.SequenceRevision.from_dict(
-            event_data["sequence_revision"], _client=None, _sequence=None
+            event_data["sequence_revision"],
+            _sequence=_sparse_sequence(event_data["sequence_revision"], client),
+            _client=client,
         )
 
 
+@_event(EventType.NEW_PANEL_REVISION)
 class NewPanelRevisionEvent(WebhookEvent):
     """An event sent when a new panel revision is saved."""
 
-    def __init__(self, event_data: models.PanelRevisionCreatedEvent):
-        super().__init__(event_data)
-        self.panel_revision = types.PanelRevision.from_dict(event_data["panel_revision"], _sequence=None, _client=None)
-
-
-class NewContactSheetEvent(WebhookEvent):
-    """An event sent when a new contact sheet is exported."""
-
-    def __init__(self, event_data: models.ContactSheetCreatedEvent):
-        super().__init__(event_data)
-        self.asset = types.Asset.from_dict(event_data["asset"], _client=None)
-        self.user = types.User.from_dict(event_data["user"], _client=None)
-        self.show = types.Show.from_dict(event_data["show"], _client=None)
-        self.sequence = types.Sequence.from_dict(event_data["sequence"], _show=self.show, _client=None, _episode=None)
-        self.sequence_revision = types.SequenceRevision.from_dict(
-            event_data["sequence_revision"], _client=None, _sequence=self.sequence
+    def __init__(
+        self,
+        data: models.Event,
+        client: _client.Client | None,
+    ):
+        super().__init__(data)
+        event_data = cast(models.PanelRevisionCreatedEvent, data)
+        self.panel_revision = types.PanelRevision.from_dict(
+            event_data["panel_revision"],
+            _sequence=_sparse_sequence(event_data["panel_revision"], client),
+            _client=client,
         )
 
 
+@_event(EventType.NEW_CONTACT_SHEET)
+class NewContactSheetEvent(WebhookEvent):
+    """An event sent when a new contact sheet is exported."""
+
+    def __init__(
+        self,
+        data: models.Event,
+        client: _client.Client | None,
+    ):
+        super().__init__(data)
+        event_data = cast(models.ContactSheetCreatedEvent, data)
+        self.asset = types.Asset.from_dict(event_data["asset"], _client=client)
+        self.user = types.User.from_dict(event_data["user"], _client=client)
+        self.show = types.Show.from_dict(event_data["show"], _client=client)
+        self.sequence = types.Sequence.from_dict(
+            event_data["sequence"], _show=self.show, _episode=None, _client=client
+        )
+        self.sequence_revision = types.SequenceRevision.from_dict(
+            event_data["sequence_revision"],
+            _sequence=self.sequence,
+            _client=client,
+        )
+
+
+@_event(EventType.PING)
 class PingEvent(WebhookEvent):
     """An event sent when the server is asked to ping a webhook."""
 
-    def __init__(self, event_data: models.PingEvent):
-        super().__init__(event_data)
+    def __init__(self, data: models.Event, client: _client.Client | None):
+        super().__init__(data)
+        event_data = cast(models.PingEvent, data)
         self.event_time = dateutil.parser.parse(event_data["event_time"])
-        self.user = types.User.from_dict(event_data["user"], _client=None)
-
-
-T = TypeVar("T", bound=WebhookEvent)
-WebhookHandlerType = Callable[[T], Coroutine[Any, Any, None]]
+        self.user = types.User.from_dict(event_data["user"], _client=client)
 
 
 class WebhookHandler:
@@ -155,7 +250,9 @@ class WebhookHandler:
     ):
         self.secret = secret
         self.handler = handler
-        self._sub_handlers: dict[Type[WebhookEvent], list[WebhookHandlerType[WebhookEvent]]] = {}
+        self._sub_handlers: dict[
+            EventFactory[WebhookEvent], list[WebhookHandlerType[WebhookEvent]]
+        ] = {}
 
     def set_secret(self, secret: str) -> None:
         """
@@ -165,7 +262,11 @@ class WebhookHandler:
         """
         self.secret = secret
 
-    def handle(self, event_type: Type[T]) -> Callable[[WebhookHandlerType[T]], WebhookHandlerType[T]]:
+    def handle(
+        self, event_type: EventFactory[WebhookEventType]
+    ) -> Callable[
+        [WebhookHandlerType[WebhookEventType]], WebhookHandlerType[WebhookEventType]
+    ]:
         """
         A decorator for specialised webhook handlers that handle a specific type of event.
 
@@ -173,23 +274,35 @@ class WebhookHandler:
         :return: A decorator which registers the decorated function as a webhook handler
         """
 
-        def decorator(f: WebhookHandlerType[T]) -> WebhookHandlerType[T]:
+        def decorator(
+            f: WebhookHandlerType[WebhookEventType],
+        ) -> WebhookHandlerType[WebhookEventType]:
             self._add_handler(event_type, f)
             return f
 
         return decorator
 
-    def _add_handler(self, event_type: Type[T], handler: WebhookHandlerType[T]) -> None:
+    def _add_handler(
+        self,
+        event_type: EventFactory[WebhookEventType],
+        handler: WebhookHandlerType[WebhookEventType],
+    ) -> None:
         if event_type not in self._sub_handlers:
             self._sub_handlers[event_type] = []
-        self._sub_handlers[event_type].append(cast(WebhookHandlerType[WebhookEvent], handler))
+        self._sub_handlers[event_type].append(
+            cast(WebhookHandlerType[WebhookEvent], handler)
+        )
 
-    def _get_handlers(self, event_type: Type[T]) -> list[WebhookHandlerType[T]]:
+    def _get_handlers(
+        self, event_type: EventFactory[WebhookEventType]
+    ) -> list[WebhookHandlerType[WebhookEventType]]:
         if (handlers := self._sub_handlers.get(event_type)) is not None:
-            return cast(list[WebhookHandlerType[T]], handlers)
+            return cast(list[WebhookHandlerType[WebhookEventType]], handlers)
         return []
 
-    async def __call__(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+    async def __call__(
+        self, request: aiohttp.web.BaseRequest, *, client: _client.Client | None = None
+    ) -> aiohttp.web.Response:
         if self.secret is None:
             raise errors.FlixError("no secret set for webhook handler")
 
@@ -197,13 +310,22 @@ class WebhookHandler:
         sig = flix.signature(data, self.secret, as_hex=True)
         if (req_sig := request.headers.get("X-Flix-Signature-256")) != sig:
             if req_sig is not None:
-                logger.warning("dropping '%s' event with unexpected signature", request.headers.get("X-Flix-Event"))
+                logger.warning(
+                    (
+                        "dropping '%s' event with unexpected signature"
+                        " (did you specify the right secret?)"
+                    ),
+                    request.headers.get("X-Flix-Event"),
+                )
             return aiohttp.web.Response(status=400)
 
-        event = _parse_event(request.headers.get("X-Flix-Event"), json.loads(data))
-        await self.handler(event)
+        event_type = EventType(request.headers.get("X-Flix-Event"))
+        event_body = cast(models.Event, json.loads(data))
+        event_factory = _EVENT_TYPES[event_type]
+        event = event_factory(event_body, client)
 
-        for sub_handler in self._get_handlers(type(event)):
+        await self.handler(event)
+        for sub_handler in self._get_handlers(event_factory):
             await sub_handler(event)
 
         return aiohttp.web.Response()

--- a/flixpy/flix/lib/webhooks.py
+++ b/flixpy/flix/lib/webhooks.py
@@ -7,7 +7,7 @@ import aiohttp.web
 import dateutil.parser
 
 import flix
-from flix.lib import models, types
+from flix.lib import errors, models, types
 
 __all__ = [
     "EventType",
@@ -191,7 +191,7 @@ class WebhookHandler:
 
     async def __call__(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
         if self.secret is None:
-            raise RuntimeError("no secret set for webhook handler")
+            raise errors.FlixError("no secret set for webhook handler")
 
         data = await request.read()
         sig = flix.signature(data, self.secret, as_hex=True)

--- a/flixpy/flix/lib/websocket.py
+++ b/flixpy/flix/lib/websocket.py
@@ -6,7 +6,7 @@ import urllib.parse
 import uuid
 from collections.abc import Iterable, AsyncIterator, Generator
 from types import TracebackType
-from typing import TypeVar, AsyncIterable, TypedDict, cast, Type, Generic, Any
+from typing import TypeVar, TypedDict, cast, Type, Generic, Any
 
 import aiohttp
 import yarl
@@ -299,7 +299,7 @@ class ChainWaiter(Generic[WebsocketMessageType]):
     @property
     def result(self) -> WebsocketMessageType:
         if self._result is None:
-            raise RuntimeError("attempted to access result before completion")
+            raise errors.FlixError("attempted to access result before completion")
         return self._result
 
     async def __aiter__(self) -> AsyncIterator[WebsocketMessage]:
@@ -337,7 +337,7 @@ class Websocket:
         self._client = _client
         access_key = _client.access_key
         if access_key is None:
-            raise RuntimeError("must be authenticated to open websocket")
+            raise errors.FlixError("must be authenticated to open websocket")
         self._access_key = access_key
         self.client_id = str(uuid.uuid4())
         self._ws: aiohttp.ClientWebSocketResponse | None = None
@@ -374,7 +374,7 @@ class Websocket:
 
     async def __aiter__(self) -> AsyncIterator[WebsocketMessage]:
         if self._ws is None:
-            raise RuntimeError("must open websocket before iterating")
+            raise errors.FlixError("must open websocket before iterating")
 
         msg: aiohttp.WSMessage
         async for msg in self._ws:

--- a/flixpy/poetry.lock
+++ b/flixpy/poetry.lock
@@ -998,38 +998,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.5.1"
+version = "1.8.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
-    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
-    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
-    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
-    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
-    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
-    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
-    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
-    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
-    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
-    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
-    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
-    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
-    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
-    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
-    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
-    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
-    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
-    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
-    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
-    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
-    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
-    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
-    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
-    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
-    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
-    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
+    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
+    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
+    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
+    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
+    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
+    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
+    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
+    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
+    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
+    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
+    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
+    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
+    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
+    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
+    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
+    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
+    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
 ]
 
 [package.dependencies]
@@ -1040,6 +1040,7 @@ typing-extensions = ">=4.1.0"
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
 install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
 reports = ["lxml"]
 
 [[package]]


### PR DESCRIPTION
Adds new ShotGrid example which demonstrates:

* Setting up a webhook server
* Listening for publish events
* Exporting a QuickTime for a published sequence revision
* Downloading an exported QuickTime
* Creating a ShotGrid version entity from a sequence revision
* Uploading a QuickTime to a ShotGrid version

Additional changes:

* Add automatic authentication of the client if you pass a username and password to the constructor to better support long-lived sessions and be more robust to the server going down
    * The client will automatically authenticate before any request or when opening a websocket connection if we don't have a valid access key
    * If an HTTP request was rejected with 401 we will try to authenticate and try the request again once
    * By default, a background task will be run to extend the session once per hour
 * Add a convenience function to make it easier to start webhook servers
 * Enable attaching an authenticated client to a webhook server so that methods on events can be used, e.g. `PublishEditorialEvent.sequence_revision.export_quicktime`
 * Other smaller changes to be more consistent (better error classes, more standard naming of methods)