### PR TITLE
[main][579317](Bug) [PUBLIC] A ConnectError occurs frequently in Maya if the Flix Maya Extension is installed and Flix is not open

### DIFF
--- a/flixpy/flix/extension/client.py
+++ b/flixpy/flix/extension/client.py
@@ -315,9 +315,7 @@ class Extension:
             try:
                 registered_client = await self._get_registered_client()
             except (errors.FlixError, httpx.HTTPError):
-                logger.debug(
-                    "could not connect to client, waiting 10 seconds before retrying..."
-                )
+                logger.debug("could not connect to client, waiting 10 seconds before retrying...")
                 await asyncio.sleep(10)
                 continue
 

--- a/flixpy/flix/extension/client.py
+++ b/flixpy/flix/extension/client.py
@@ -315,7 +315,7 @@ class Extension:
             try:
                 registered_client = await self._get_registered_client()
             except (errors.FlixError, httpx.HTTPError):
-                logger.exception(
+                logger.debug(
                     "could not connect to client, waiting 10 seconds before retrying..."
                 )
                 await asyncio.sleep(10)

--- a/flixpy/pyproject.toml
+++ b/flixpy/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flix-sdk"
-version = "2.0.1"
+version = "2.0.2"
 description = "Python SDK and command-line utilities for Flix"
 authors = []
 homepage = "https://www.foundry.com/products/flix"


### PR DESCRIPTION
Update to log connection errors at the debug level