### PR TITLE
[main][583542](Bug) [ext] Maya: Sending panels to Flix 7.0 from Maya fails with an error

### DIFF
--- a/flixpy/flix/extension/extension_api.yaml
+++ b/flixpy/flix/extension/extension_api.yaml
@@ -200,7 +200,7 @@ paths:
             schema:
               $ref: '#/components/schemas/BulkPanelRequest'
       responses:
-        '200':
+        '201':
           description: The panel creation has been scheduled
           content:
             application/json:

--- a/flixpy/flix/extension/extension_api/api/panel_management/panel_controller_create.py
+++ b/flixpy/flix/extension/extension_api/api/panel_management/panel_controller_create.py
@@ -28,10 +28,10 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, PanelRequestResponse]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = PanelRequestResponse.from_dict(response.json())
+    if response.status_code == HTTPStatus.CREATED:
+        response_201 = PanelRequestResponse.from_dict(response.json())
 
-        return response_200
+        return response_201
     if response.status_code == HTTPStatus.BAD_REQUEST:
         response_400 = cast(Any, None)
         return response_400


### PR DESCRIPTION
# Changes
- Update the extension API to expect a 201 response for the panel create endpoint

![image](https://github.com/user-attachments/assets/df89da93-ed94-4b29-9e91-9c26a6e3ff6b)
