### PR TITLE
[main][604259](UserStory) Updates MessageEditorialImportStatus for 8.0

### DIFF
--- a/flixpy/flix/lib/websocket.py
+++ b/flixpy/flix/lib/websocket.py
@@ -183,9 +183,13 @@ class MessageEditorialImportStatus(KnownWebsocketMessage):
         error: str
 
     class Status(enum.Enum):
+        RELINK = "relink"
+        VERSIONUP = "versionUp"
+        NEWPANEL = "newPanel"
+        ARTWORK_REUSED = "newPanelArtworkReuse"
+        DUPLICATED = "newPanelDuplicated"
         PENDING = "pending"
         IN_PROGRESS = "inProgress"
-        COMPLETE = "complete"
         UNSUPPORTED = "unsupported"
         ERRORED = "errored"
 


### PR DESCRIPTION
As part of 598486, we changed the Import Status message on complete to reflect the panel import type. This change updates the SDK to reflect those changes. A follow up commit will be required for the editorial tests to update the dependencies.

See:
https://github.com/TheFoundryVisionmongers/flix-server/pull/2882/files
